### PR TITLE
Basic GitHub Actions for this repo

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,19 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: make
+      run: linux/make
+    - name: check executable
+      run: bash -c "[[ -x linux/demo ]]"

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: make
-      run: linux/make
+      run: make
+      working-directory: linux
     - name: check executable
       run: bash -c "[[ -x linux/demo ]]"

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -9,12 +9,12 @@ on:
 jobs:
   build:
     name: Build and analyse default scheme using xcodebuild command
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set Default Scheme
+      - name: Set Default Scheme  
         run: |
           cd MacOS/tiff_g4_test
           scheme_list=$(xcodebuild -list -json | tr -d "\n")

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -29,4 +29,8 @@ jobs:
           if [ $scheme = default ]; then scheme=$(cat default); fi
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          xcodebuild clean build analyze -scheme "$scheme" -"$filetype_parameter" "$file_to_build" | xcpretty && exit ${PIPESTATUS[0]}
+          xcodebuild clean build analyze -scheme "$scheme" -"$filetype_parameter" "$file_to_build" | xcpretty && exit ${PIPESTATUS[0]} | tee demo.log
+          result_code=${PIPESTATUS[0]}
+          cat demo.log
+          exit $result_code
+        

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -1,0 +1,32 @@
+name: Xcode - Build and Analyze
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    name: Build and analyse default scheme using xcodebuild command
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set Default Scheme
+        run: |
+          cd MacOS/tiff_g4_test
+          scheme_list=$(xcodebuild -list -json | tr -d "\n")
+          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
+          echo $default | cat >default
+          echo Using default scheme: $default
+      - name: Build
+        env:
+          scheme: ${{ 'default' }}
+        run: |
+          cd MacOS/tiff_g4_test
+          if [ $scheme = default ]; then scheme=$(cat default); fi
+          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
+          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
+          xcodebuild clean build analyze -scheme "$scheme" -"$filetype_parameter" "$file_to_build" | xcpretty && exit ${PIPESTATUS[0]}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ The API:
 --------
 Please consult the [Wiki](https://github.com/bitbank2/TIFF_G4/wiki) for detailed info about each method exposed by the TIFFG4 class. I've also provided a C interface to the library and example code which compiles from a makefile for Linux.<br>
 
+Automated builds and testing:
+-----------------------------
+
+![Alt text](https://github.com/commercetest/TIFF_G4/actions/workflows/c-cpp.yml/badge.svg)
+![Alt text](https://github.com/commercetest/TIFF_G4/actions/workflows/objective-c-xcode.yml/badge.svg)
 
 If you find this code useful, please consider becoming a sponsor or sending a donation.
 


### PR DESCRIPTION
### Overview
Created GitHub actions to build in linux and XCode.

### Details
Here are two GitHub actions, one for the linux code and another for the XCode project. They run the respective builds, and for the linux code the generated program is run.

I've also added the badges that are generated. These would need editing to map to the URL of your repo rather than my fork in order to track that repo's GitHub actions. 

### Notes

- More information is available in https://github.com/commercetest/TIFF_G4/issues/1
- LMK if you'd like me to create a branch for this rather than submitting a PR for the `master` branch. GitHub actions are generally run for the default i.e. `master` branch though so the current approach is easier to test and evaluate.
- The Actions can be revised as and when unit tests are added and/or when the fuzzing code is applicable for linux, etc.
- I didn't try to create an Action to run `examples/function_tests/function_tests.ino` as that sets up a serial port which might not be available.
