### PR TITLE
Add ESP-IDF integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "src/tiffg4.c"
+                       INCLUDE_DIRS "src")

--- a/src/TIFF_G4.h
+++ b/src/TIFF_G4.h
@@ -14,7 +14,7 @@
 #ifndef __TIFFG4__
 #define __TIFFG4__
 
-#if defined( __MACH__ ) || defined( __LINUX__ )
+#if defined( __MACH__ ) || defined( __LINUX__ ) || defined( ESP_PLATFORM )
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>


### PR DESCRIPTION
This allows to add TIFF_G4 to a C project based on the ESP-IDF framework from Espressif.

To use:
- copy the main `TIFF_G4` directory into the `components` directory of the ESP project
- add `#include "TIFF_G4.h"` where needed